### PR TITLE
Use github.token by default.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ permissions:
 ```yaml
 - uses: yogeshlonkar/wait-for-jobs@v0
   with:
-    # GitHub token to access actions API
-    # required: true
-    gh-token: ${{ secrets.GITHUB_TOKEN }}
 
     # To ignore jobs that are skipped from given list of job dependencies
     # default: 'false'

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ branding:
 inputs:
   gh-token:
     description: GitHub token to access API
+    default: '${{github.token}}'
     required: true
   ignore-skipped:
     description: To ignore jobs that are skipped from given list of job dependencies


### PR DESCRIPTION
Hi @yogeshlonkar,

I'm really enjoying your GitHub Action and have just integrated it into our deployment pipeline for our project, [Onyxia](https://onyxia.sh).

I wanted to let you know that it's no longer necessary for users to explicitly provide a token; GitHub can automatically generate one by default. You can learn more about this feature here:

[GitHub Automatic Token Authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

Best regards,
