### PR TITLE
add pending status to isCompleted

### DIFF
--- a/src/Dependency.ts
+++ b/src/Dependency.ts
@@ -39,6 +39,9 @@ export class Dependency {
             case "queued":
                 info(`job "${name}" not started yet 👀`);
                 return false;
+            case "pending":
+                info(`job "${name}" is pending 👀`);
+                return false;
             default:
                 // this should never happen
                 throw new Error(`error: unknown status "${status}" of job "${name}"`);


### PR DESCRIPTION
The action currently fails when it checks on a `pending` job. 
```
checking status of jobs: [...] 
Error: error: unknown status "pending" of job "..."
```